### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scripts To Rule Them All
 
 This is a set of boilerplate scripts describing the [normalized script pattern
-that GitHub uses in its projects](link-to-strta-blog-post). While these
+that GitHub uses in its projects](http://githubengineering.com/scripts-to-rule-them-all/). While these
 patterns can work for projects based on any framework or language, these
 particular examples are for a simple Ruby on Rails application.
 


### PR DESCRIPTION
So it links to http://githubengineering.com/scripts-to-rule-them-all.
