### PR TITLE
Install more in bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following is a list of scripts and their primary responsibilities.
 
 `script/bootstrap` is used solely for fulfilling dependencies of the project.
 
-This can mean RubyGems, npm packages, Git submodules, etc.
+This can mean RubyGems, npm packages, Homebrew packages, Ruby versions, Git submodules, etc.
 
 The goal is to make sure all required dependencies are installed.
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,7 +7,22 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+echo "==> Installing Ruby…"
+rbenv install --skip-existing
+
 echo "==> Installing gem dependencies…"
+which bundle 2>&1 > /dev/null || {
+  gem install bundler
+}
 bundle check --path vendor/gems 2>&1 > /dev/null || {
   bundle install --path vendor/gems --quiet --without production
 }
+
+if [ "$(uname -s)" = "Darwin" ] && brew --prefix 2>&1 > /dev/null; then
+  echo "==> Installing Homebrew dependencies…"
+  brew update
+  brew tap homebrew/bundle 2>/dev/null
+  brew bundle check 2>&1 > /dev/null || {
+    brew bundle
+  }
+fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,22 +7,27 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-echo "==> Installing Ruby…"
-rbenv install --skip-existing
-
-echo "==> Installing gem dependencies…"
-which bundle 2>&1 > /dev/null || {
-  gem install bundler
-}
-bundle check --path vendor/gems 2>&1 > /dev/null || {
-  bundle install --path vendor/gems --quiet --without production
-}
-
-if [ "$(uname -s)" = "Darwin" ] && brew --prefix 2>&1 > /dev/null; then
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   echo "==> Installing Homebrew dependencies…"
   brew update
   brew tap homebrew/bundle 2>/dev/null
-  brew bundle check 2>&1 > /dev/null || {
+  brew bundle check 2>&1 >/dev/null || {
     brew bundle
+  }
+fi
+
+if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+  echo "==> Installing Ruby…"
+  rbenv install
+  which bundle 2>&1 >/dev/null || {
+    gem install bundler
+    rbenv rehash
+  }
+fi
+
+if [ -f "Gemfile" ]; then
+  echo "==> Installing gem dependencies…"
+  bundle check --path vendor/gems 2>&1 >/dev/null || {
+    bundle install --path vendor/gems --quiet --without production
   }
 fi


### PR DESCRIPTION
Currently there's assumptions elsewhere that `rbenv` and `bundle` are used so `bootstrap` should probably also check to see if they are installed. Also, if you're on OS X use `brew bundle` to install Homebrew dependencies from a `Brewfile`.

CC @maddox for review. Feel free to reject this if you feel it's overcomplicating things; no hard feelings if so.