### PR TITLE
Do less during bootstrap and update

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -16,7 +16,7 @@ fi
 
 if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
   echo "==> Installing Ruby…"
-  rbenv install
+  rbenv install --skip-existing 
   which bundle 2>&1 >/dev/null || {
     gem install bundler
     rbenv rehash

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,10 +8,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
-  echo "==> Installing Homebrew dependencies…"
-  brew update
-  brew tap homebrew/bundle 2>/dev/null
   brew bundle check 2>&1 >/dev/null || {
+    echo "==> Installing Homebrew dependencies…"
     brew bundle
   }
 fi

--- a/script/setup
+++ b/script/setup
@@ -16,7 +16,7 @@ script/bootstrap
 
 echo "===> Setting up DB..."
 # reset database to a fresh state.
-bin/rake db:reset
+bin/rake db:create db:reset
 
 if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
   # Only things for a development environment will run inside here

--- a/script/setup
+++ b/script/setup
@@ -7,6 +7,11 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
+  brew update
+  brew tap homebrew/bundle 2>/dev/null
+fi
+
 script/bootstrap
 
 echo "===> Setting up DB..."

--- a/script/update
+++ b/script/update
@@ -10,4 +10,4 @@ script/bootstrap
 
 echo "==> Updating db..."
 # run all database migrations to ensure everything is up to date.
-bin/rake db:create db:migrate
+bin/rake db:migrate


### PR DESCRIPTION
I added the scripts to a new project, and ran into a few things:

* during script/bootstrap: `brew update` adds some 7 seconds when it's usually not doing anything
* script/update runs `rake db:create`, which generates output about the databases existing already

To fix:

* move tapping `homebrew/bundle` and `brew update` to `script/setup`
* remove `rake db:create` from `script/update` to `script/create`

I also was wondering about `rbenv install` running every time. I think we want to check that every time, since .ruby-version could be updated, but should include --skip-existing to not try to re-install it if it's already installed.