### PR TITLE
Tweak Homebrew code in setup/bootstrap.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,6 +8,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
+  brew update
+
   brew bundle check 2>&1 >/dev/null || {
     echo "==> Installing Homebrew dependencies…"
     brew bundle
@@ -16,7 +18,7 @@ fi
 
 if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
   echo "==> Installing Ruby…"
-  rbenv install --skip-existing 
+  rbenv install --skip-existing
   which bundle 2>&1 >/dev/null || {
     gem install bundler
     rbenv rehash

--- a/script/setup
+++ b/script/setup
@@ -7,11 +7,6 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
-  brew update
-  brew tap homebrew/bundle 2>/dev/null
-fi
-
 script/bootstrap
 
 echo "===> Setting up DB..."


### PR DESCRIPTION
As `script/bootstrap` is the only place using Homebrew's code then it makes sense to just move all the `brew` invocations there.

Also, `brew bundle` auto-taps/installs `Homebrew/homebrew-bundle` now so it doesn't need the manual `brew tap` any more.

CC @maddox and @technicalpickles for thoughts.
