### PR TITLE
Minor improvement, fix some bugs

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/bootstrap: Resolve all dependencies that the application requires to
 #                   run.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,12 +5,12 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "${0%/*}/.."
 
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   brew update
 
-  brew bundle check 2>&1 >/dev/null || {
+  brew bundle check >/dev/null 2>&1 || {
     echo "==> Installing Homebrew dependencies…"
     brew bundle
   }
@@ -19,7 +19,7 @@ fi
 if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
   echo "==> Installing Ruby…"
   rbenv install --skip-existing
-  which bundle 2>&1 >/dev/null || {
+  which bundle >/dev/null 2>&1 || {
     gem install bundler
     rbenv rehash
   }
@@ -27,7 +27,7 @@ fi
 
 if [ -f "Gemfile" ]; then
   echo "==> Installing gem dependencies…"
-  bundle check --path vendor/gems 2>&1 >/dev/null || {
+  bundle check --path vendor/gems >/dev/null 2>&1 || {
     bundle install --path vendor/gems --quiet --without production
   }
 fi

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/cibuild: Setup environment for CI to run tests. This is primarily
 #                 designed to run on the continuous integration server.

--- a/script/cibuild
+++ b/script/cibuild
@@ -5,7 +5,7 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "${0%/*}/.."
 
 echo "Tests started at..."
 date "+%H:%M:%S"
@@ -18,13 +18,13 @@ export RUBY_HEAP_SLOTS_INCREMENT=400000
 export RUBY_HEAP_SLOTS_GROWTH_FACTOR=1
 
 # setup environment
-export RAILS_ROOT=$(cd "$(dirname $0)"/.. && pwd)
+export RAILS_ROOT=$(cd "${0%/*}/.." && pwd)
 export RAILS_ENV="test"
 export RACK_ROOT="$RAILS_ROOT"
 export RACK_ENV="$RAILS_ENV"
 
 test -d "/usr/share/rbenv/shims" && {
-  export PATH=/usr/share/rbenv/shims:$PATH
+  export PATH="/usr/share/rbenv/shims:$PATH"
 }
 export RBENV_VERSION="2.1.6"
 

--- a/script/console
+++ b/script/console
@@ -7,14 +7,14 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "${0%/*}/.."
 
 if [ -n "$1" ]; then
   # use first argument as an environment name. Use this to decide how to connect
   # to the appropriate console.
-  if [ "$1" == "production" ]; then
+  if [ "$1" = "production" ]; then
     heroku run rails console --app heroku-app-name
-  elif [ "$1" == "staging" ]; then
+  elif [ "$1" = "staging" ]; then
     heroku run rails console --app heroku-app-name-staging
   else
     echo "Sorry, I don't know how to connect to the '$1' environment."

--- a/script/console
+++ b/script/console
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/console: Launch a console for the application. Optionally allow an
 #                 environment to be passed in to let the script handle the

--- a/script/server
+++ b/script/server
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/server: Launch the application and any extra required processes
 #                locally.

--- a/script/server
+++ b/script/server
@@ -5,7 +5,7 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "${0%/*}/.."
 
 # ensure everything in the app is up to date.
 script/update

--- a/script/setup
+++ b/script/setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/setup: Set up application for the first time after cloning, or set it
 #               back to the initial first unused state.

--- a/script/setup
+++ b/script/setup
@@ -5,7 +5,7 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "${0%/*}/.."
 
 script/bootstrap
 
@@ -18,6 +18,7 @@ if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
   # Do things that need to be done to the application to set up for the first
   # time. Or things needed to be run to to reset the application back to first
   # use experience. These things are scoped to the application's domain.
+  :
 fi
 
 echo "==> App is now ready to go!"

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/test: Run test suite for application. Optionally pass in a path to an
 #              individual test file to run a single test.

--- a/script/test
+++ b/script/test
@@ -6,11 +6,11 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "${0%/*}/.."
 
 [ -z "$DEBUG" ] || set -x
 
-export RACK_ROOT=$(cd "$(dirname $0)"/.. && pwd)
+export RACK_ROOT=$(cd "${0%/*}/.." && pwd)
 
 if [ "$RAILS_ENV" = "test" ] || [ "$RACK_ENV" = "test" ]; then
   # if executed and the environment is already set to `test`, then we want a

--- a/script/update
+++ b/script/update
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/update: Update application to run for its current checkout.
 

--- a/script/update
+++ b/script/update
@@ -4,7 +4,7 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "${0%/*}/.."
 
 script/bootstrap
 


### PR DESCRIPTION
Some minor improvements:

 - Replace useless use of `dirname` with standard `${var%/*}`.

 - Fix missing double quotes

 - Make some construct work with standard POSIX shell:

  + Using `=` instead of `==` for old test `[...]`
  + Using `:` for no-op operator instead of empty `if` body, even in `bash`, the empty `if` body will raise an error

PS: And also many places used ` 2>&1 >/dev/null`, it does not make sense, should be `>/dev/null 2>&1` if you want to discard all output.