### PR TITLE
Avoid unbound variable usage.

### DIFF
--- a/script/server
+++ b/script/server
@@ -10,8 +10,7 @@ cd "$(dirname "$0")/.."
 # ensure everything in the app is up to date.
 script/update
 
-test -z "$RACK_ENV" &&
-  RACK_ENV='development'
+RACK_ENV=${RACK_ENV:-development}
 
 # boot the app and any other necessary processes.
 foreman start -p 9393


### PR DESCRIPTION
If executed with `set -u` the error `RACK_ENV: unbound variable` is thrown, this avoids it.. That doesn't really matter since only `set -e` is set, but I like this syntax better :neckbeard: 