### PR TITLE
Bash style fixes.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/bootstrap: Resolve all dependencies that the application requires to
 #                   run.
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   brew update
 
-  brew bundle check 2>&1 >/dev/null || {
+  brew bundle check &>/dev/null || {
     echo "==> Installing Homebrew dependencies…"
     brew bundle
   }
@@ -19,7 +19,7 @@ fi
 if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
   echo "==> Installing Ruby…"
   rbenv install --skip-existing
-  which bundle 2>&1 >/dev/null || {
+  which bundle &>/dev/null || {
     gem install bundler
     rbenv rehash
   }
@@ -27,7 +27,7 @@ fi
 
 if [ -f "Gemfile" ]; then
   echo "==> Installing gem dependencies…"
-  bundle check --path vendor/gems 2>&1 >/dev/null || {
+  bundle check --path vendor/gems &>/dev/null || {
     bundle install --path vendor/gems --quiet --without production
   }
 fi

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/cibuild: Setup environment for CI to run tests. This is primarily
 #                 designed to run on the continuous integration server.
@@ -11,11 +11,11 @@ echo "Tests started at..."
 date "+%H:%M:%S"
 
 # GC customizations
-export RUBY_GC_MALLOC_LIMIT=79000000
-export RUBY_HEAP_MIN_SLOTS=800000
-export RUBY_HEAP_FREE_MIN=100000
-export RUBY_HEAP_SLOTS_INCREMENT=400000
-export RUBY_HEAP_SLOTS_GROWTH_FACTOR=1
+export RUBY_GC_MALLOC_LIMIT="79000000"
+export RUBY_HEAP_MIN_SLOTS="800000"
+export RUBY_HEAP_FREE_MIN="100000"
+export RUBY_HEAP_SLOTS_INCREMENT="400000"
+export RUBY_HEAP_SLOTS_GROWTH_FACTOR="1"
 
 # setup environment
 export RAILS_ROOT=$(cd "$(dirname $0)"/.. && pwd)
@@ -24,7 +24,7 @@ export RACK_ROOT="$RAILS_ROOT"
 export RACK_ENV="$RAILS_ENV"
 
 test -d "/usr/share/rbenv/shims" && {
-  export PATH=/usr/share/rbenv/shims:$PATH
+  export PATH="/usr/share/rbenv/shims:$PATH"
 }
 export RBENV_VERSION="2.1.6"
 

--- a/script/console
+++ b/script/console
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/console: Launch a console for the application. Optionally allow an
 #                 environment to be passed in to let the script handle the

--- a/script/server
+++ b/script/server
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/server: Launch the application and any extra required processes
 #                locally.

--- a/script/setup
+++ b/script/setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/setup: Set up application for the first time after cloning, or set it
 #               back to the initial first unused state.
@@ -18,6 +18,7 @@ if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
   # Do things that need to be done to the application to set up for the first
   # time. Or things needed to be run to to reset the application back to first
   # use experience. These things are scoped to the application's domain.
+  :
 fi
 
 echo "==> App is now ready to go!"

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/test: Run test suite for application. Optionally pass in a path to an
 #              individual test file to run a single test.

--- a/script/update
+++ b/script/update
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/update: Update application to run for its current checkout.
 


### PR DESCRIPTION
- Use `/bin/bash` everywhere as we're using Bashisms.
- Quote all exported variables
- Fix incorrect use of `2>&1 >` to instead be `&>`
- Fix syntax error

Thanks to @Gnouc for submitting these in #21.