### PR TITLE
Consistent use of arrows

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -9,7 +9,7 @@ cd "$(dirname "$0")/.."
 
 script/bootstrap
 
-echo "===> Setting up DB…"
+echo "==> Setting up DB…"
 # reset database to a fresh state.
 bin/rake db:create db:reset
 

--- a/script/test
+++ b/script/test
@@ -29,7 +29,7 @@ else
   script/update
 fi
 
-echo "===> Running tests…"
+echo "==> Running tests…"
 
 if [ -n "$1" ]; then
   # pass arguments to test call. This is useful for calling a single test.


### PR DESCRIPTION
Keep keeping consistency :) This is follow-up for https://github.com/github/scripts-to-rule-them-all/pull/28.

There were two types of arrows used in the project (`==>` and `===>`). In order to decide which arrow to keep, a number of occurrences have been calculated:

```
> grep -rwn './' -e '"==>'
.//script/bootstrap:14:    echo "==> Installing Homebrew dependencies…"
.//script/bootstrap:20:  echo "==> Installing Ruby…"
.//script/bootstrap:29:  echo "==> Installing gem dependencies…"
.//script/setup:24:echo "==> App is now ready to go!"
.//script/update:11:echo "==> Updating db…"

# `==>` appears 5 times
```

and

```
> grep -rwn './' -e '"===>'
.//script/setup:12:echo "===> Setting up DB…"
.//script/test:32:echo "===> Running tests…"

# `===>` appears 2 times
```

Because numbers do not lie, `==>` won :smile: