### PR TITLE
Use the Travis setup from ShellCheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: bash
-install:
-  - wget http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb
-  - dpkg -x shellcheck_0.3.7-5_amd64.deb shellcheck/
+addons:
+  apt:
+    sources:
+    - debian-sid
+    packages:
+    - shellcheck
 script:
-  - shellcheck/usr/bin/shellcheck script/*
+  - shellcheck script/*
 sudo: false


### PR DESCRIPTION
The method from the shellcheck docs will ensure running the latest instead of a pinned version