### PR TITLE
make RACK_ENV available to the server process

### DIFF
--- a/script/server
+++ b/script/server
@@ -11,7 +11,7 @@ cd "$(dirname "$0")/.."
 script/update
 
 test -z "$RACK_ENV" &&
-  RACK_ENV='development'
+  export RACK_ENV='development'
 
 # boot the app and any other necessary processes.
 foreman start -p 9393


### PR DESCRIPTION
Thank you for this repo! I've been adding these to a bunch of my services lately! 💯

I noticed that the env var has to be explicitly exported in `script/server` to be available. At least that was the case in my use of these scripts.

https://github.com/bostonaholic/http-server/commit/a8e5065cb5e52a313daa4a571e1c80a2c143d8fd